### PR TITLE
Fix download link of TurboVNC, VirtualGL and libjpeg-turbo

### DIFF
--- a/remocolab.py
+++ b/remocolab.py
@@ -270,13 +270,13 @@ def _setup_nvidia_gl():
   subprocess.Popen(["Xorg", "-seat", "seat-1", "-allowMouseOpenFail", "-novtswitch", "-nolisten", "tcp"])
 
 def _setupVNC():
-  libjpeg_ver = "2.0.4"
-  virtualGL_ver = "2.6.3"
+  libjpeg_ver = "2.0.5"
+  virtualGL_ver = "2.6.4"
   turboVNC_ver = "2.2.5"
 
-  libjpeg_url = "https://astuteinternet.dl.sourceforge.net/project/libjpeg-turbo/{0}/libjpeg-turbo-official_{0}_amd64.deb".format(libjpeg_ver)
-  virtualGL_url = "https://astuteinternet.dl.sourceforge.net/project/virtualgl/{0}/virtualgl_{0}_amd64.deb".format(virtualGL_ver)
-  turboVNC_url = "https://astuteinternet.dl.sourceforge.net/project/turbovnc/{0}/turbovnc_{0}_amd64.deb".format(turboVNC_ver)
+  libjpeg_url = "https://github.com/demotomohiro/turbovnc/releases/download/2.2.5/libjpeg-turbo-official_{0}_amd64.deb".format(libjpeg_ver)
+  virtualGL_url = "https://github.com/demotomohiro/turbovnc/releases/download/2.2.5/virtualgl_{0}_amd64.deb".format(virtualGL_ver)
+  turboVNC_url = "https://github.com/demotomohiro/turbovnc/releases/download/2.2.5/turbovnc_{0}_amd64.deb".format(turboVNC_ver)
 
   _download(libjpeg_url, "libjpeg-turbo.deb")
   _download(virtualGL_url, "virtualgl.deb")


### PR DESCRIPTION
remocolab uses [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo), [VirtualGL](https://github.com/VirtualGL/virtualgl) and [TurboVNC](https://github.com/TurboVNC/turbovnc).
They release binary files only in sourceforge but their download link often change.
It seems sourceforge never provide download URL that can be used with wget for long time.
I put copies of these files in github so that my script can always download them from same URL.
